### PR TITLE
Add photo frames to hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,20 @@
   <!-- Tailwind CSS via CDN -->
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <style>
-    /* Custom styles for Bauhaus shapes */
+    .photo-frame {
+      width: 170px;
+      height: 120px;
+      object-fit: cover;
+      border: 2px solid #ddd;
+    }
   </style>
 </head>
 <body class="bg-white text-gray-800">
   <!-- Hero Section -->
   <section class="py-20">
-    <div class="container mx-auto px-4 flex flex-col-reverse lg:flex-row items-center">
+    <div class="container mx-auto px-4 flex flex-col lg:flex-row items-center">
       <!-- Text -->
-      <div class="w-full lg:w-1/2 mt-10 lg:mt-0">
+      <div class="left-half w-full lg:w-1/2 mt-10 lg:mt-0">
 
         <h1 class="text-3xl lg:text-4xl font-bold mb-6 leading-snug">
           <span class="block">Moi c\'est Loïc Emmanuel&nbsp;–</span>
@@ -36,26 +41,12 @@
           <a href="#" class="bg-blue-900 hover:bg-blue-800 text-white font-semibold px-6 py-3 rounded shadow">Télécharger mon CV</a>
         </div>
       </div>
-      <!-- Shapes -->
-
-      <div class="w-full lg:w-1/2 flex justify-center lg:justify-end">
-        <div class="grid grid-cols-3 gap-2 max-w-[400px]">
-          <div class="w-full aspect-square bg-[#F56565]"></div>
-          <div class="w-full aspect-square bg-[#ECC94B] rounded-full -translate-x-2"></div>
-          <div class="w-full aspect-square bg-[#2D93AD] rotate-45 translate-y-1"></div>
-          <div class="w-full aspect-square bg-[#003844] rounded-lg -translate-y-1"></div>
-          <div class="w-full aspect-square bg-[#88AB75] scale-110"></div>
-          <div class="w-full aspect-square bg-[#F56565] rounded-full -translate-x-1 translate-y-1"></div>
-          <div class="w-full aspect-square bg-[#2D93AD] -rotate-45 translate-x-1"></div>
-          <div class="w-full aspect-square bg-[#88AB75] -translate-y-1"></div>
-          <div class="w-full aspect-square bg-[#ECC94B] rounded-lg translate-x-1"></div>
-
-      <div class="w-full lg:w-1/2 flex justify-center">
-        <div class="relative w-64 h-64">
-          <div class="absolute bg-[#88AB75] rounded-full w-40 h-40 -top-4 -left-4"></div>
-          <div class="absolute bg-[#2D93AD] w-32 h-32 rotate-45 right-0 top-10"></div>
-          <div class="absolute bg-[#003844] w-16 h-16 bottom-4 left-20"></div>
-
+      <!-- Photos -->
+      <div class="right-half w-full lg:w-1/2 flex justify-center lg:justify-end mt-10 lg:mt-0">
+        <div class="flex flex-col items-center space-y-4">
+          <img src="images/project1.svg" alt="Photo 1" class="photo-frame">
+          <img src="images/project2.svg" alt="Photo 2" class="photo-frame">
+          <img src="images/project3.svg" alt="Photo 3" class="photo-frame">
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- divide hero section into `left-half` and `right-half`
- insert three photo frames in the right side
- add a custom `.photo-frame` CSS class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684490fa6fe083299a8245541c3464c1